### PR TITLE
feat(network): add peer leave detection and events

### DIFF
--- a/peer/src-tauri/src/lib.rs
+++ b/peer/src-tauri/src/lib.rs
@@ -4,12 +4,10 @@ mod utils;
 use tokio::sync::Mutex;
 use std::sync::Arc;
 
-use crate::state::{AppState, File, Peer};
+use crate::state::{AppState, PeerSerializable, File, AppStateWrapper};
 use anyhow::Result;
 use tauri::Manager;
 
-// in all commands replace AppState by AppStateWrapper
-struct AppStateWrapper(Arc<Mutex<AppState>>);
 
 #[tauri::command]
 async fn get_paths(state: tauri::State<'_, AppStateWrapper>) -> Result<Vec<String>, String> {
@@ -64,7 +62,7 @@ async fn clear_files(state: tauri::State<'_, AppStateWrapper>) -> Result<(), Str
 }
 
 #[tauri::command]
-async fn get_peers(state: tauri::State<'_, AppStateWrapper>, app: tauri::AppHandle) -> Result<Vec<Peer>, String> {
+async fn get_peers(state: tauri::State<'_, AppStateWrapper>, app: tauri::AppHandle) -> Result<Vec<PeerSerializable>, String> {
     let mut state = state.0.lock().await;
     state.get_peers(app).await.map_err(|err| err.to_string())
 }

--- a/peer/src-tauri/src/network.rs
+++ b/peer/src-tauri/src/network.rs
@@ -7,7 +7,6 @@ use iroh::Endpoint;
 use tauri::Emitter;
 use tauri::{AppHandle, Manager};
 use tokio::sync::Mutex;
-use tokio::time::interval;
 use tokio::time::Instant;
 
 use crate::state::Peer;
@@ -96,8 +95,9 @@ pub async fn background_cleanup_task(
     app: AppHandle,
     timeout: tokio::time::Duration,
 ) {
+    let mut interval = tokio::time::interval(timeout);
     loop {
-        interval(timeout); // Similar to sleep
+        interval.tick().await;
         let mut peers_lock = peers.lock().await;
 
         let left_peers: Vec<Peer> = peers_lock

--- a/peer/src/routes/+layout.svelte
+++ b/peer/src/routes/+layout.svelte
@@ -23,6 +23,11 @@
       description: `Node ID: ${event.payload[0].node_id}`,
     });
   });
+  listen<Peer>('peer::left', (event) => {
+    toast.info(`Peer left: ${event.payload.username}`, {
+      description: `Node ID: ${event.payload.node_id}`,
+    });
+  });
 
 </script>
 

--- a/peer/src/routes/peers/+page.svelte
+++ b/peer/src/routes/peers/+page.svelte
@@ -35,6 +35,9 @@
   listen<[Peer, Peer]>('peer::username_changed', () => {
     getPeers();
   });
+  listen<Peer>('peer::left', () => {
+    getPeers();
+  });
   function getPeers() {
     invoke("get_peers")
       .then((data) => {


### PR DESCRIPTION
- Implement background cleanup task to track peer last_seen timestamps
- Emit "peer::left" event on timeout (10s default)
- Add PeerSerializable struct for event payloads
- Fixes #6 