### PR TITLE
feat: add current tab highlighting to sidebar

### DIFF
--- a/peer/src/lib/components/custom/sidebar.svelte
+++ b/peer/src/lib/components/custom/sidebar.svelte
@@ -35,7 +35,7 @@
 </script>
 <div class="flex">
 
-<Sidebar.Root>
+<Sidebar.Root collapsible="icon">
   <Sidebar.Content>
     <Sidebar.Group>
       <Sidebar.GroupLabel>Application</Sidebar.GroupLabel>

--- a/peer/src/lib/components/custom/sidebar.svelte
+++ b/peer/src/lib/components/custom/sidebar.svelte
@@ -4,6 +4,7 @@
   import MessageSquare from "@lucide/svelte/icons/message-square";
   import CircleUser from "@lucide/svelte/icons/circle-user";
   import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+  import { page } from "$app/stores";
 
   const nav = [
     {
@@ -43,7 +44,7 @@
         <Sidebar.Menu>
           {#each nav as item (item.name)}
             <Sidebar.MenuItem>
-              <Sidebar.MenuButton>
+              <Sidebar.MenuButton isActive={item.route === $page.url.pathname}>
                 {#snippet child({ props })}
                   <a href={item.route} {...props}>
                     <item.icon />

--- a/peer/src/lib/components/ui/sidebar/sidebar-trigger.svelte
+++ b/peer/src/lib/components/ui/sidebar/sidebar-trigger.svelte
@@ -22,7 +22,7 @@
 	data-slot="sidebar-trigger"
 	variant="ghost"
 	size="icon"
-	class={cn("size-7", className)}
+	class={cn("size-7 m-2", className)}
 	type="button"
 	onclick={(e) => {
 		onclick?.(e);


### PR DESCRIPTION
### Description
## Change sidebar style from `none` to `icon` for desktop

#### Before
<img width="361" height="436" alt="image" src="https://github.com/user-attachments/assets/ad4da7ee-0dfb-4f96-a061-2711c62d3ad4" />


#### After
<img width="460" height="512" alt="image" src="https://github.com/user-attachments/assets/37423da7-1c93-4bba-98ea-1425ca6a3ac4" />


## Add current tab highlighting

#### Before
<img width="646" height="283" alt="image" src="https://github.com/user-attachments/assets/a502ccf4-1161-4e7b-b6e9-7adc62891d59" />

#### After
<img width="621" height="270" alt="image" src="https://github.com/user-attachments/assets/4a2b93bb-4300-43b0-bee6-17cc2b5686be" />
<br />
<br />

- [x] I have updated the relevant documentation
- [x] I have added consistent logging in my code
